### PR TITLE
Update SSHClient.m

### DIFF
--- a/ios/SSHClient.m
+++ b/ios/SSHClient.m
@@ -15,7 +15,7 @@ int uploadedPerc = 0;
 
 - (instancetype)init {
     if ((self = [super init])) {
-        _session = [NMSSHSession new];
+        _session = [[NMSSHSession alloc] initWithHost:@"" andUsername:@""];
         _sftpSession = [[NMSFTP alloc] init];
         _key = [[NSString alloc] init];
         _downloadContinue = false;


### PR DESCRIPTION
NMSSHSession - 'new' is unavailable and init is explicitly marked as NS_UNAVAILABLE in the header precluding alloc > init.

trying this on a fork as a workaround.